### PR TITLE
Consumer-review fixes (v2.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+## 2.5.0
+
+Fixes from a downstream consumer's adversarial review. This is a **minor** bump —
+it includes small but real behavior changes (see "Behavior changes" below).
+
+### Behavior changes (read before upgrading)
+- **`Message` structured output:** passing `responseSchema` without
+  `responseMimeType` now auto-defaults `responseMimeType: 'application/json'`
+  (the SDK requires it and does not add it). Previously such a call returned a
+  400 or unparseable prose. Explicit `responseMimeType` is still honored.
+- **`init()` no longer validates connectivity by default.** `Message`,
+  `Embedding`, and `ImageGenerator` previously called `models.list()`
+  unconditionally during `init()`. This is now gated behind `healthCheck: true`
+  (default `false`), matching `BaseGemini`. If you relied on `init()` as a
+  startup credentials gate, pass `healthCheck: true`. `models.list()` is a
+  different IAM surface than `generateContent` and added a per-instance
+  round-trip.
+
+### Added
+- **`usage.estimatedCost`** — every `send()`/`generate()` result and
+  `getLastUsage()` now include an estimated USD cost from `MODEL_PRICING`
+  (`null` when the model is unpriced). Thinking ("thoughts") tokens are billed at
+  the output rate and are now included in cost and exposed as
+  `usage.thoughtsTokens`.
+- **Concurrency-safe per-call usage.** `Message.send()` and
+  `ImageGenerator.generate()` return `result.usage` computed synchronously from
+  that call's own response. `getLastUsage()` still reflects the instance's last
+  call and is unsafe to read across concurrent sends on a shared instance — use
+  `result.usage`.
+- **Pricing helpers exported:** `MODEL_PRICING`, `MODEL_ALIASES`,
+  `resolvePricing()`, `computeCost()`. `resolvePricing` follows `-latest`
+  aliases and peels version-build suffixes (e.g. `gemini-2.5-flash-001` →
+  `gemini-2.5-flash`).
+- **`validateSchema()`** JSON-Schema validator exported (for cross-package
+  symmetry; Gemini enforces schemas natively).
+
+### Fixed
+- `estimateCost()` now uses `resolvePricing()` and returns `null` cost fields for
+  unknown models (was `0`), consistent with `usage.estimatedCost`.
+- `estimatedCost` no longer returns `null` for a priced model when the API echoes
+  a version-suffixed build id in `modelVersion`.
+
+### Dependencies
+- `@google/genai` `^2.10.0` → `^2.12.0` (no breaking changes to the used surface).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,8 @@ Shared foundation. Not typically instantiated directly.
 - `init(force?)` — Creates chat session; runs `models.list()` health check only if `healthCheck: true`
 - `seed(examples, opts?)` — Add example pairs to chat history
 - `getHistory()` / `clearHistory()` — Manage chat history
-- `getLastUsage()` — Structured usage data after API calls (includes `groundingMetadata` when grounding enabled)
+- `getLastUsage()` — Structured usage data after API calls (includes `groundingMetadata` when grounding enabled, and `estimatedCost` from MODEL_PRICING — `null` if unpriced). Reflects the instance's LAST call; unsafe under concurrent `send()`s — prefer the per-call `result.usage` (computed synchronously from that response via `_usageFromResponse()`)
+- `resolvePricing(modelId)` / `computeCost(modelId, in, out)` — pricing helpers; resolve `-latest` aliases via `MODEL_ALIASES`, return `null` for unknown models (exported from index)
 - `estimate(payload)` / `estimateCost(payload)` — Token/cost estimation
 - `enableGrounding` / `groundingConfig` — Google Search grounding (available on all classes)
 - `resourceExhaustedRetries` / `resourceExhaustedDelay` — 429 rate-limit retry with exponential backoff (default: 5 retries, 1000ms)
@@ -107,7 +108,8 @@ Multi-turn text conversation. Extends BaseGemini.
 ### Message (`message.js`)
 Stateless one-off messages. Uses `generateContent()`. Extends BaseGemini.
 - `send(payload, opts?)` → `{ text, data?, usage }`
-- Supports structured output via `responseSchema` / `responseMimeType`
+- Supports structured output via `responseSchema` / `responseMimeType`. Passing `responseSchema` alone now auto-defaults `responseMimeType: 'application/json'` (the SDK requires it and won't add it)
+- `init()` runs the `models.list()` connectivity check ONLY when `healthCheck: true` (was unconditional); same gating applied to `Embedding` and `ImageGenerator`
 - `getHistory()`, `clearHistory()`, `seed()` are no-ops
 
 ### ToolAgent (`tool-agent.js`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,8 @@ new Transformer({ vertexai: true, project: 'my-gcp-project' });
 ```javascript
 // Named exports
 import { Transformer, Chat, Message, ToolAgent, CodeAgent, RagAgent, Embedding, ImageGenerator, BaseGemini, log } from 'ak-gemini';
-import { extractJSON, attemptJSONRecovery } from 'ak-gemini';
+import { extractJSON, attemptJSONRecovery, validateSchema } from 'ak-gemini';
+import { MODEL_PRICING, MODEL_ALIASES, resolvePricing, computeCost } from 'ak-gemini';
 
 // Default export (namespace object)
 import AI from 'ak-gemini';
@@ -216,11 +217,11 @@ const { Transformer, Chat } = require('ak-gemini');
 
 ## Testing Strategy
 
-- "No mocks" approach — all tests use real Gemini API calls
+- **Two test tiers:** (1) live-API suites (`*.test.js`) use real Gemini API calls — no mocks; (2) `consumer-fixes.test.js` is offline/mocked (stubs the SDK client on the instance) and safe to run anytime for the 2.5.0 fix logic
 - **Do NOT run tests during development** — they are slow (real API calls) and expensive. Use `npm run typecheck` and `npm run build:cjs` to verify changes.
 - Test timeout: 30 seconds (AI calls take 5-15 seconds)
 - Rate limiting (429 errors) can cause flaky failures — retry after waiting
-- Test files: `base.test.js`, `transformer.test.js`, `chat.test.js`, `message.test.js`, `tool-agent.test.js`, `code-agent.test.js`, `rag-agent.test.js`, `embedding.test.js`, `json-helpers.test.js`
+- Test files: `base.test.js`, `transformer.test.js`, `chat.test.js`, `message.test.js`, `tool-agent.test.js`, `code-agent.test.js`, `rag-agent.test.js`, `embedding.test.js`, `json-helpers.test.js`, `consumer-fixes.test.js` (offline/mocked)
 
 ## Key Design Patterns
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -147,6 +147,8 @@ console.log(result.data);
 
 Key difference from `Chat`: `result.data` contains the parsed JSON object. `result.text` contains the raw string.
 
+> **Note:** `responseSchema` requires `responseMimeType: 'application/json'`. If you pass `responseSchema` without a `responseMimeType`, ak-gemini now auto-defaults it to `'application/json'` (logged at debug). Passing an explicit `responseMimeType` is still honored.
+
 ### When to Use Message
 
 - Classification, tagging, or labeling
@@ -1037,9 +1039,12 @@ const usage = instance.getLastUsage();
 //   attempts: 1,             // 1 = first try, 2+ = retries needed
 //   modelVersion: 'gemini-2.5-flash-001',  // actual model that responded
 //   requestedModel: 'gemini-2.5-flash',    // model you requested
-//   timestamp: 1710000000000
+//   timestamp: 1710000000000,
+//   estimatedCost: 0.00123   // USD from MODEL_PRICING; null if model unpriced
 // }
 ```
+
+> **Concurrency:** `getLastUsage()` reflects the **instance's last completed call** and mutates on every `send()`. If you share one instance across concurrent `send()` calls, `getLastUsage()` can report another call's tokens. Use the per-call **`result.usage`** returned by `send()`/`generate()` instead — it is computed synchronously from that call's own response and is safe under concurrency. `result.usage` includes `estimatedCost` too.
 
 ### Cost Estimation
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1040,11 +1040,16 @@ const usage = instance.getLastUsage();
 //   modelVersion: 'gemini-2.5-flash-001',  // actual model that responded
 //   requestedModel: 'gemini-2.5-flash',    // model you requested
 //   timestamp: 1710000000000,
+//   thoughtsTokens: 0,       // thinking tokens, billed at output rate (in totalTokens + cost)
 //   estimatedCost: 0.00123   // USD from MODEL_PRICING; null if model unpriced
 // }
 ```
 
-> **Concurrency:** `getLastUsage()` reflects the **instance's last completed call** and mutates on every `send()`. If you share one instance across concurrent `send()` calls, `getLastUsage()` can report another call's tokens. Use the per-call **`result.usage`** returned by `send()`/`generate()` instead — it is computed synchronously from that call's own response and is safe under concurrency. `result.usage` includes `estimatedCost` too.
+> **Thinking tokens:** for thinking-enabled models, `thoughtsTokens` are billed at the output rate and are included in both `totalTokens` and `estimatedCost`. `responseTokens` is candidate (visible) output only.
+
+> **Concurrency:** `getLastUsage()` reflects the **instance's last completed call** and mutates on every `send()` — it is **not** safe to read across concurrent sends on a shared instance. The **stateless** classes (`Message`, `ImageGenerator`) return a per-call **`result.usage`** computed synchronously from that call's own response, which *is* concurrency-safe — use it when sharing one instance across concurrent calls. The stateful classes (`Chat`, `Transformer`, `RagAgent`, `ToolAgent`, `CodeAgent`) maintain history/rounds and are not designed to be shared across concurrent calls; their `result.usage` is derived from instance state.
+
+> **`estimatedCost` / `MODEL_ALIASES` caveat:** `estimatedCost` resolves `-latest` aliases and version-suffixed builds via `MODEL_PRICING`/`MODEL_ALIASES`. Alias→price mappings are pinned as of 2026-07 (e.g. `gemini-flash-latest` → `gemini-3.5-flash`); when Google rotates what a `-latest` alias points to, `estimatedCost` for that alias may be wrong until the table is updated. Pin explicit model ids for billing-grade accuracy.
 
 ### Cost Estimation
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,14 @@ const msg = new Message({
 
 const result = await msg.send('Alice works at Acme in New York.');
 // result.data → { entities: ['Alice', 'Acme', 'New York'] }
+// result.usage → { promptTokens, responseTokens, thoughtsTokens, totalTokens, estimatedCost, ... }
 ```
+
+> **`responseSchema` requires `responseMimeType: 'application/json'`.** As of 2.5.0, passing `responseSchema` without a `responseMimeType` auto-defaults it to `'application/json'` — you can omit the line above. An explicit `responseMimeType` is still honored.
+
+> **Connectivity check is opt-in.** `Message`, `Embedding`, and `ImageGenerator` do **not** ping the API during `init()` unless you pass `healthCheck: true` (default `false`, as of 2.5.0). The first `send()`/`embed()`/`generate()` surfaces auth/connectivity errors on its own.
+
+> **Per-call usage under concurrency.** Read `result.usage` (computed from that call's own response) rather than `getLastUsage()` when sharing a `Message`/`ImageGenerator` instance across concurrent `send()`s — `getLastUsage()` reflects only the instance's last completed call.
 
 ### ToolAgent — Agent with User-Provided Tools
 

--- a/base.js
+++ b/base.js
@@ -91,9 +91,25 @@ const MODEL_ALIASES = {
  */
 function resolvePricing(modelId) {
 	if (!modelId) return null;
-	if (MODEL_PRICING[modelId]) return MODEL_PRICING[modelId];
-	const alias = MODEL_ALIASES[modelId];
-	if (alias && MODEL_PRICING[alias]) return MODEL_PRICING[alias];
+	const tryKey = (id) => {
+		if (MODEL_PRICING[id]) return MODEL_PRICING[id];
+		const alias = MODEL_ALIASES[id];
+		if (alias && MODEL_PRICING[alias]) return MODEL_PRICING[alias];
+		return null;
+	};
+	let hit = tryKey(modelId);
+	if (hit) return hit;
+	// The API echoes a pinned build in modelVersion (e.g. 'gemini-2.5-flash-001',
+	// 'gemini-3-flash-preview-09-2025') even when you request the bare id. Peel
+	// trailing '-<digits>' groups and retry until a priced id matches.
+	let stripped = modelId;
+	while (true) {
+		const next = stripped.replace(/-\d{2,}$/, '');
+		if (next === stripped) break;
+		stripped = next;
+		hit = tryKey(stripped);
+		if (hit) return hit;
+	}
 	return null;
 }
 
@@ -497,7 +513,8 @@ class BaseGemini {
 			timestamp: meta.timestamp,
 			groundingMetadata: meta.groundingMetadata || null,
 			modelStatus: meta.modelStatus || null,
-			estimatedCost: computeCost(meta.modelVersion || meta.requestedModel, promptTokens, responseTokens)
+			estimatedCost: computeCost(meta.modelVersion, promptTokens, responseTokens)
+				?? computeCost(meta.requestedModel, promptTokens, responseTokens)
 		};
 	}
 
@@ -527,7 +544,8 @@ class BaseGemini {
 			timestamp: Date.now(),
 			groundingMetadata: response?.candidates?.[0]?.groundingMetadata || null,
 			modelStatus: response?.modelStatus || null,
-			estimatedCost: computeCost(modelVersion || this.modelName, promptTokens, responseTokens)
+			estimatedCost: computeCost(modelVersion, promptTokens, responseTokens)
+				?? computeCost(this.modelName, promptTokens, responseTokens)
 		};
 	}
 

--- a/base.js
+++ b/base.js
@@ -71,7 +71,46 @@ const MODEL_PRICING = {
 	'gemini-embedding-001': { input: 0.15, output: 0 }
 };
 
-export { DEFAULT_SAFETY_SETTINGS, DEFAULT_THINKING_CONFIG, THINKING_SUPPORTED_MODELS, MODEL_PRICING, DEFAULT_MAX_OUTPUT_TOKENS };
+/**
+ * Alias → canonical model id map for pricing resolution.
+ * Google publishes floating `-latest` aliases that resolve server-side to a
+ * concrete model; they never appear in MODEL_PRICING directly. Map them to the
+ * canonical id whose rate they currently bill at so estimatedCost can resolve.
+ * Revisit when Google rotates what an alias points to.
+ */
+const MODEL_ALIASES = {
+	'gemini-flash-latest': 'gemini-3.5-flash',
+	'gemini-pro-latest': 'gemini-3.1-pro-preview',
+	'gemini-flash-lite-latest': 'gemini-3.1-flash-lite'
+};
+
+/**
+ * Resolves pricing for a model id, following `-latest` aliases.
+ * @param {string|null|undefined} modelId
+ * @returns {{ input: number, output: number }|null} Pricing, or null if unknown.
+ */
+function resolvePricing(modelId) {
+	if (!modelId) return null;
+	if (MODEL_PRICING[modelId]) return MODEL_PRICING[modelId];
+	const alias = MODEL_ALIASES[modelId];
+	if (alias && MODEL_PRICING[alias]) return MODEL_PRICING[alias];
+	return null;
+}
+
+/**
+ * Computes estimated USD cost from token counts using MODEL_PRICING.
+ * @param {string|null|undefined} modelId
+ * @param {number} promptTokens
+ * @param {number} responseTokens
+ * @returns {number|null} Cost in USD, or null when pricing is unknown.
+ */
+function computeCost(modelId, promptTokens, responseTokens) {
+	const pricing = resolvePricing(modelId);
+	if (!pricing) return null;
+	return (promptTokens / 1_000_000) * pricing.input + (responseTokens / 1_000_000) * pricing.output;
+}
+
+export { DEFAULT_SAFETY_SETTINGS, DEFAULT_THINKING_CONFIG, THINKING_SUPPORTED_MODELS, MODEL_PRICING, MODEL_ALIASES, DEFAULT_MAX_OUTPUT_TOKENS, resolvePricing, computeCost };
 
 // ── BaseGemini Class ─────────────────────────────────────────────────────────
 
@@ -444,16 +483,51 @@ class BaseGemini {
 		const cumulative = this._cumulativeUsage || { promptTokens: 0, responseTokens: 0, totalTokens: 0, attempts: 1 };
 		const useCumulative = cumulative.attempts > 0;
 
+		const promptTokens = useCumulative ? cumulative.promptTokens : meta.promptTokens;
+		const responseTokens = useCumulative ? cumulative.responseTokens : meta.responseTokens;
+		const totalTokens = useCumulative ? cumulative.totalTokens : meta.totalTokens;
+
 		return {
-			promptTokens: useCumulative ? cumulative.promptTokens : meta.promptTokens,
-			responseTokens: useCumulative ? cumulative.responseTokens : meta.responseTokens,
-			totalTokens: useCumulative ? cumulative.totalTokens : meta.totalTokens,
+			promptTokens,
+			responseTokens,
+			totalTokens,
 			attempts: useCumulative ? cumulative.attempts : 1,
 			modelVersion: meta.modelVersion,
 			requestedModel: meta.requestedModel,
 			timestamp: meta.timestamp,
 			groundingMetadata: meta.groundingMetadata || null,
-			modelStatus: meta.modelStatus || null
+			modelStatus: meta.modelStatus || null,
+			estimatedCost: computeCost(meta.modelVersion || meta.requestedModel, promptTokens, responseTokens)
+		};
+	}
+
+	/**
+	 * Builds a usage object directly from a single API response, WITHOUT reading
+	 * mutable instance state (`lastResponseMetadata`/`_cumulativeUsage`). Safe to
+	 * call under concurrent send() calls on a shared instance — unlike
+	 * getLastUsage(), which reflects whichever call most recently mutated the
+	 * instance and can cross-talk between concurrent sends.
+	 * @param {Object} response - A single generateContent() response
+	 * @param {number} [attempts=1] - Attempts this call consumed
+	 * @returns {UsageData}
+	 * @protected
+	 */
+	_usageFromResponse(response, attempts = 1) {
+		const promptTokens = response?.usageMetadata?.promptTokenCount || 0;
+		const responseTokens = response?.usageMetadata?.candidatesTokenCount || 0;
+		const totalTokens = response?.usageMetadata?.totalTokenCount || 0;
+		const modelVersion = response?.modelVersion || null;
+		return {
+			promptTokens,
+			responseTokens,
+			totalTokens,
+			attempts,
+			modelVersion,
+			requestedModel: this.modelName,
+			timestamp: Date.now(),
+			groundingMetadata: response?.candidates?.[0]?.groundingMetadata || null,
+			modelStatus: response?.modelStatus || null,
+			estimatedCost: computeCost(modelVersion || this.modelName, promptTokens, responseTokens)
 		};
 	}
 

--- a/base.js
+++ b/base.js
@@ -115,15 +115,18 @@ function resolvePricing(modelId) {
 
 /**
  * Computes estimated USD cost from token counts using MODEL_PRICING.
+ * Thinking ("thoughts") tokens are billed at the output rate.
  * @param {string|null|undefined} modelId
  * @param {number} promptTokens
  * @param {number} responseTokens
+ * @param {number} [thoughtsTokens=0] - Thinking tokens (billed at output rate)
  * @returns {number|null} Cost in USD, or null when pricing is unknown.
  */
-function computeCost(modelId, promptTokens, responseTokens) {
+function computeCost(modelId, promptTokens, responseTokens, thoughtsTokens = 0) {
 	const pricing = resolvePricing(modelId);
 	if (!pricing) return null;
-	return (promptTokens / 1_000_000) * pricing.input + (responseTokens / 1_000_000) * pricing.output;
+	return (promptTokens / 1_000_000) * pricing.input
+		+ ((responseTokens + thoughtsTokens) / 1_000_000) * pricing.output;
 }
 
 export { DEFAULT_SAFETY_SETTINGS, DEFAULT_THINKING_CONFIG, THINKING_SUPPORTED_MODELS, MODEL_PRICING, MODEL_ALIASES, DEFAULT_MAX_OUTPUT_TOKENS, resolvePricing, computeCost };
@@ -292,16 +295,26 @@ class BaseGemini {
 		const chatOptions = this._getChatCreateOptions();
 		this.chatSession = this.genAIClient.chats.create(chatOptions);
 
-		if (this.healthCheck) {
-			try {
-				await this._withRetry(() => this.genAIClient.models.list());
-				log.debug(`${this.constructor.name}: API connection successful.`);
-			} catch (e) {
-				throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
-			}
-		}
+		await this._healthCheckPing();
 
 		log.debug(`${this.constructor.name}: Chat session initialized.`);
+	}
+
+	/**
+	 * Opt-in connectivity check via `models.list()` — runs only when
+	 * `healthCheck: true`. Fails fast (no exponential backoff): a readiness probe
+	 * should surface a bad config immediately, not after ~30s of 429 retries.
+	 * @returns {Promise<void>}
+	 * @protected
+	 */
+	async _healthCheckPing() {
+		if (!this.healthCheck) return;
+		try {
+			await this.genAIClient.models.list();
+			log.debug(`${this.constructor.name}: API connection successful.`);
+		} catch (e) {
+			throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
+		}
 	}
 
 	/**
@@ -471,12 +484,17 @@ class BaseGemini {
 	 */
 	_captureMetadata(response) {
 		const modelStatus = response?.modelStatus || null;
+		const promptTokens = response.usageMetadata?.promptTokenCount || 0;
+		const responseTokens = response.usageMetadata?.candidatesTokenCount || 0;
+		const thoughtsTokens = response.usageMetadata?.thoughtsTokenCount || 0;
 		this.lastResponseMetadata = {
 			modelVersion: response.modelVersion || null,
 			requestedModel: this.modelName,
-			promptTokens: response.usageMetadata?.promptTokenCount || 0,
-			responseTokens: response.usageMetadata?.candidatesTokenCount || 0,
-			totalTokens: response.usageMetadata?.totalTokenCount || 0,
+			promptTokens,
+			responseTokens,
+			thoughtsTokens,
+			// totalTokenCount includes thoughts; fall back to summing the parts.
+			totalTokens: response.usageMetadata?.totalTokenCount || (promptTokens + responseTokens + thoughtsTokens),
 			timestamp: Date.now(),
 			groundingMetadata: response.candidates?.[0]?.groundingMetadata || null,
 			modelStatus
@@ -496,16 +514,18 @@ class BaseGemini {
 		if (!this.lastResponseMetadata) return null;
 
 		const meta = this.lastResponseMetadata;
-		const cumulative = this._cumulativeUsage || { promptTokens: 0, responseTokens: 0, totalTokens: 0, attempts: 1 };
+		const cumulative = this._cumulativeUsage || { promptTokens: 0, responseTokens: 0, totalTokens: 0, thoughtsTokens: 0, attempts: 1 };
 		const useCumulative = cumulative.attempts > 0;
 
 		const promptTokens = useCumulative ? cumulative.promptTokens : meta.promptTokens;
 		const responseTokens = useCumulative ? cumulative.responseTokens : meta.responseTokens;
+		const thoughtsTokens = useCumulative ? (cumulative.thoughtsTokens || 0) : (meta.thoughtsTokens || 0);
 		const totalTokens = useCumulative ? cumulative.totalTokens : meta.totalTokens;
 
 		return {
 			promptTokens,
 			responseTokens,
+			thoughtsTokens,
 			totalTokens,
 			attempts: useCumulative ? cumulative.attempts : 1,
 			modelVersion: meta.modelVersion,
@@ -513,9 +533,23 @@ class BaseGemini {
 			timestamp: meta.timestamp,
 			groundingMetadata: meta.groundingMetadata || null,
 			modelStatus: meta.modelStatus || null,
-			estimatedCost: computeCost(meta.modelVersion, promptTokens, responseTokens)
-				?? computeCost(meta.requestedModel, promptTokens, responseTokens)
+			estimatedCost: this._estimatedCost(meta.modelVersion, promptTokens, responseTokens, thoughtsTokens)
 		};
+	}
+
+	/**
+	 * Estimated USD cost, preferring the model id the API echoed (`modelVersion`)
+	 * and falling back to the requested model when that build isn't priced.
+	 * @param {string|null|undefined} modelVersion
+	 * @param {number} promptTokens
+	 * @param {number} responseTokens
+	 * @param {number} [thoughtsTokens=0]
+	 * @returns {number|null}
+	 * @protected
+	 */
+	_estimatedCost(modelVersion, promptTokens, responseTokens, thoughtsTokens = 0) {
+		return computeCost(modelVersion, promptTokens, responseTokens, thoughtsTokens)
+			?? computeCost(this.modelName, promptTokens, responseTokens, thoughtsTokens);
 	}
 
 	/**
@@ -532,11 +566,13 @@ class BaseGemini {
 	_usageFromResponse(response, attempts = 1) {
 		const promptTokens = response?.usageMetadata?.promptTokenCount || 0;
 		const responseTokens = response?.usageMetadata?.candidatesTokenCount || 0;
-		const totalTokens = response?.usageMetadata?.totalTokenCount || 0;
+		const thoughtsTokens = response?.usageMetadata?.thoughtsTokenCount || 0;
+		const totalTokens = response?.usageMetadata?.totalTokenCount || (promptTokens + responseTokens + thoughtsTokens);
 		const modelVersion = response?.modelVersion || null;
 		return {
 			promptTokens,
 			responseTokens,
+			thoughtsTokens,
 			totalTokens,
 			attempts,
 			modelVersion,
@@ -544,8 +580,7 @@ class BaseGemini {
 			timestamp: Date.now(),
 			groundingMetadata: response?.candidates?.[0]?.groundingMetadata || null,
 			modelStatus: response?.modelStatus || null,
-			estimatedCost: computeCost(modelVersion, promptTokens, responseTokens)
-				?? computeCost(this.modelName, promptTokens, responseTokens)
+			estimatedCost: this._estimatedCost(modelVersion, promptTokens, responseTokens, thoughtsTokens)
 		};
 	}
 
@@ -592,14 +627,16 @@ class BaseGemini {
 	 */
 	async estimateCost(nextPayload) {
 		const tokenInfo = await this.estimate(nextPayload);
-		const pricing = MODEL_PRICING[this.modelName] || { input: 0, output: 0 };
+		const pricing = resolvePricing(this.modelName);
 
 		return {
 			inputTokens: tokenInfo.inputTokens,
 			model: this.modelName,
 			pricing: pricing,
-			estimatedInputCost: (tokenInfo.inputTokens / 1_000_000) * pricing.input,
-			note: 'Cost is for input tokens only; output cost depends on response length'
+			estimatedInputCost: pricing ? (tokenInfo.inputTokens / 1_000_000) * pricing.input : null,
+			note: pricing
+				? 'Cost is for input tokens only; output cost depends on response length'
+				: `No pricing known for model "${this.modelName}"; estimatedInputCost is null`
 		};
 	}
 

--- a/embedding.js
+++ b/embedding.js
@@ -57,14 +57,7 @@ export default class Embedding extends BaseGemini {
 		// Connectivity check is opt-in (healthCheck: true) — avoids an extra
 		// round-trip and the models.list() IAM surface. First embed() is a fine
 		// error signal on its own.
-		if (this.healthCheck) {
-			try {
-				await this._withRetry(() => this.genAIClient.models.list());
-				log.debug(`${this.constructor.name}: API connection successful.`);
-			} catch (e) {
-				throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
-			}
-		}
+		await this._healthCheckPing();
 
 		this._initialized = true;
 		log.debug(`${this.constructor.name}: Initialized (stateless mode).`);

--- a/embedding.js
+++ b/embedding.js
@@ -54,11 +54,16 @@ export default class Embedding extends BaseGemini {
 
 		log.debug(`Initializing ${this.constructor.name} with model: ${this.modelName}...`);
 
-		try {
-			await this.genAIClient.models.list();
-			log.debug(`${this.constructor.name}: API connection successful.`);
-		} catch (e) {
-			throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
+		// Connectivity check is opt-in (healthCheck: true) — avoids an extra
+		// round-trip and the models.list() IAM surface. First embed() is a fine
+		// error signal on its own.
+		if (this.healthCheck) {
+			try {
+				await this._withRetry(() => this.genAIClient.models.list());
+				log.debug(`${this.constructor.name}: API connection successful.`);
+			} catch (e) {
+				throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
+			}
 		}
 
 		this._initialized = true;

--- a/image-generator.js
+++ b/image-generator.js
@@ -55,14 +55,7 @@ export default class ImageGenerator extends BaseGemini {
 		// Connectivity check is opt-in (healthCheck: true) — avoids an extra
 		// round-trip and the models.list() IAM surface. First generate() is a fine
 		// error signal on its own.
-		if (this.healthCheck) {
-			try {
-				await this._withRetry(() => this.genAIClient.models.list());
-				log.debug(`${this.constructor.name}: API connection successful.`);
-			} catch (e) {
-				throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
-			}
-		}
+		await this._healthCheckPing();
 
 		this._initialized = true;
 	}
@@ -120,6 +113,7 @@ export default class ImageGenerator extends BaseGemini {
 		this._cumulativeUsage = {
 			promptTokens: this.lastResponseMetadata.promptTokens,
 			responseTokens: this.lastResponseMetadata.responseTokens,
+			thoughtsTokens: this.lastResponseMetadata.thoughtsTokens,
 			totalTokens: this.lastResponseMetadata.totalTokens,
 			attempts: 1
 		};

--- a/image-generator.js
+++ b/image-generator.js
@@ -52,11 +52,16 @@ export default class ImageGenerator extends BaseGemini {
 
 		log.debug(`Initializing ${this.constructor.name} with model: ${this.modelName}...`);
 
-		try {
-			await this.genAIClient.models.list();
-			log.debug(`${this.constructor.name}: API connection successful.`);
-		} catch (e) {
-			throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
+		// Connectivity check is opt-in (healthCheck: true) — avoids an extra
+		// round-trip and the models.list() IAM surface. First generate() is a fine
+		// error signal on its own.
+		if (this.healthCheck) {
+			try {
+				await this._withRetry(() => this.genAIClient.models.list());
+				log.debug(`${this.constructor.name}: API connection successful.`);
+			} catch (e) {
+				throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
+			}
 		}
 
 		this._initialized = true;
@@ -108,6 +113,9 @@ export default class ImageGenerator extends BaseGemini {
 			config: this._buildConfig(opts)
 		}));
 
+		// Per-call usage computed synchronously from THIS response (concurrency-safe).
+		const usage = this._usageFromResponse(result);
+
 		this._captureMetadata(result);
 		this._cumulativeUsage = {
 			promptTokens: this.lastResponseMetadata.promptTokens,
@@ -134,7 +142,7 @@ export default class ImageGenerator extends BaseGemini {
 			log.warn('ImageGenerator: no images returned. Check prompt or safety filters.');
 		}
 
-		return { images, text: text || null, usage: this.getLastUsage() };
+		return { images, text: text || null, usage };
 	}
 
 	/**

--- a/index.cjs
+++ b/index.cjs
@@ -441,9 +441,22 @@ var MODEL_ALIASES = {
 };
 function resolvePricing(modelId) {
   if (!modelId) return null;
-  if (MODEL_PRICING[modelId]) return MODEL_PRICING[modelId];
-  const alias = MODEL_ALIASES[modelId];
-  if (alias && MODEL_PRICING[alias]) return MODEL_PRICING[alias];
+  const tryKey = (id) => {
+    if (MODEL_PRICING[id]) return MODEL_PRICING[id];
+    const alias = MODEL_ALIASES[id];
+    if (alias && MODEL_PRICING[alias]) return MODEL_PRICING[alias];
+    return null;
+  };
+  let hit = tryKey(modelId);
+  if (hit) return hit;
+  let stripped = modelId;
+  while (true) {
+    const next = stripped.replace(/-\d{2,}$/, "");
+    if (next === stripped) break;
+    stripped = next;
+    hit = tryKey(stripped);
+    if (hit) return hit;
+  }
   return null;
 }
 function computeCost(modelId, promptTokens, responseTokens) {
@@ -739,7 +752,7 @@ ${contextText}
       timestamp: meta.timestamp,
       groundingMetadata: meta.groundingMetadata || null,
       modelStatus: meta.modelStatus || null,
-      estimatedCost: computeCost(meta.modelVersion || meta.requestedModel, promptTokens, responseTokens)
+      estimatedCost: computeCost(meta.modelVersion, promptTokens, responseTokens) ?? computeCost(meta.requestedModel, promptTokens, responseTokens)
     };
   }
   /**
@@ -768,7 +781,7 @@ ${contextText}
       timestamp: Date.now(),
       groundingMetadata: response?.candidates?.[0]?.groundingMetadata || null,
       modelStatus: response?.modelStatus || null,
-      estimatedCost: computeCost(modelVersion || this.modelName, promptTokens, responseTokens)
+      estimatedCost: computeCost(modelVersion, promptTokens, responseTokens) ?? computeCost(this.modelName, promptTokens, responseTokens)
     };
   }
   // ── Token Estimation ─────────────────────────────────────────────────────

--- a/index.cjs
+++ b/index.cjs
@@ -263,12 +263,15 @@ function findCompleteJSONStructures(text) {
 function validateSchema(data, schema, path2 = "$") {
   const errors = [];
   if (!schema || typeof schema !== "object") return errors;
+  if (data === null && schema.nullable === true) return errors;
   if (Array.isArray(schema.enum)) {
-    const ok = schema.enum.some((v) => v === data);
+    const target = JSON.stringify(data);
+    const ok = schema.enum.some((v) => v === data || JSON.stringify(v) === target);
     if (!ok) errors.push(`${path2}: value ${JSON.stringify(data)} is not one of allowed enum values ${JSON.stringify(schema.enum)}`);
   }
   if (schema.type !== void 0) {
     const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    if (schema.nullable === true) types.push("null");
     if (!types.some((t) => matchesType(data, t))) {
       errors.push(`${path2}: expected type ${types.join("|")} but got ${describeType(data)}`);
       return errors;
@@ -279,16 +282,16 @@ function validateSchema(data, schema, path2 = "$") {
     const props = schema.properties || {};
     if (Array.isArray(schema.required)) {
       for (const key of schema.required) {
-        if (!(key in data)) errors.push(`${path2}: missing required property "${key}"`);
+        if (!Object.hasOwn(data, key)) errors.push(`${path2}: missing required property "${key}"`);
       }
     }
     if (schema.additionalProperties === false) {
       for (const key of Object.keys(data)) {
-        if (!(key in props)) errors.push(`${path2}: unexpected property "${key}" (additionalProperties is false)`);
+        if (!Object.hasOwn(props, key)) errors.push(`${path2}: unexpected property "${key}" (additionalProperties is false)`);
       }
     }
     for (const [key, subSchema] of Object.entries(props)) {
-      if (key in data) {
+      if (Object.hasOwn(data, key)) {
         errors.push(...validateSchema(
           data[key],
           /** @type {any} */
@@ -459,10 +462,10 @@ function resolvePricing(modelId) {
   }
   return null;
 }
-function computeCost(modelId, promptTokens, responseTokens) {
+function computeCost(modelId, promptTokens, responseTokens, thoughtsTokens = 0) {
   const pricing = resolvePricing(modelId);
   if (!pricing) return null;
-  return promptTokens / 1e6 * pricing.input + responseTokens / 1e6 * pricing.output;
+  return promptTokens / 1e6 * pricing.input + (responseTokens + thoughtsTokens) / 1e6 * pricing.output;
 }
 var BaseGemini = class {
   /**
@@ -558,15 +561,24 @@ var BaseGemini = class {
     logger_default.debug(`Initializing ${this.constructor.name} chat session with model: ${this.modelName}...`);
     const chatOptions = this._getChatCreateOptions();
     this.chatSession = this.genAIClient.chats.create(chatOptions);
-    if (this.healthCheck) {
-      try {
-        await this._withRetry(() => this.genAIClient.models.list());
-        logger_default.debug(`${this.constructor.name}: API connection successful.`);
-      } catch (e) {
-        throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
-      }
-    }
+    await this._healthCheckPing();
     logger_default.debug(`${this.constructor.name}: Chat session initialized.`);
+  }
+  /**
+   * Opt-in connectivity check via `models.list()` — runs only when
+   * `healthCheck: true`. Fails fast (no exponential backoff): a readiness probe
+   * should surface a bad config immediately, not after ~30s of 429 retries.
+   * @returns {Promise<void>}
+   * @protected
+   */
+  async _healthCheckPing() {
+    if (!this.healthCheck) return;
+    try {
+      await this.genAIClient.models.list();
+      logger_default.debug(`${this.constructor.name}: API connection successful.`);
+    } catch (e) {
+      throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
+    }
   }
   /**
    * Builds the options object for `genAIClient.chats.create()`.
@@ -714,12 +726,17 @@ ${contextText}
    */
   _captureMetadata(response) {
     const modelStatus = response?.modelStatus || null;
+    const promptTokens = response.usageMetadata?.promptTokenCount || 0;
+    const responseTokens = response.usageMetadata?.candidatesTokenCount || 0;
+    const thoughtsTokens = response.usageMetadata?.thoughtsTokenCount || 0;
     this.lastResponseMetadata = {
       modelVersion: response.modelVersion || null,
       requestedModel: this.modelName,
-      promptTokens: response.usageMetadata?.promptTokenCount || 0,
-      responseTokens: response.usageMetadata?.candidatesTokenCount || 0,
-      totalTokens: response.usageMetadata?.totalTokenCount || 0,
+      promptTokens,
+      responseTokens,
+      thoughtsTokens,
+      // totalTokenCount includes thoughts; fall back to summing the parts.
+      totalTokens: response.usageMetadata?.totalTokenCount || promptTokens + responseTokens + thoughtsTokens,
       timestamp: Date.now(),
       groundingMetadata: response.candidates?.[0]?.groundingMetadata || null,
       modelStatus
@@ -737,14 +754,16 @@ ${contextText}
   getLastUsage() {
     if (!this.lastResponseMetadata) return null;
     const meta = this.lastResponseMetadata;
-    const cumulative = this._cumulativeUsage || { promptTokens: 0, responseTokens: 0, totalTokens: 0, attempts: 1 };
+    const cumulative = this._cumulativeUsage || { promptTokens: 0, responseTokens: 0, totalTokens: 0, thoughtsTokens: 0, attempts: 1 };
     const useCumulative = cumulative.attempts > 0;
     const promptTokens = useCumulative ? cumulative.promptTokens : meta.promptTokens;
     const responseTokens = useCumulative ? cumulative.responseTokens : meta.responseTokens;
+    const thoughtsTokens = useCumulative ? cumulative.thoughtsTokens || 0 : meta.thoughtsTokens || 0;
     const totalTokens = useCumulative ? cumulative.totalTokens : meta.totalTokens;
     return {
       promptTokens,
       responseTokens,
+      thoughtsTokens,
       totalTokens,
       attempts: useCumulative ? cumulative.attempts : 1,
       modelVersion: meta.modelVersion,
@@ -752,8 +771,21 @@ ${contextText}
       timestamp: meta.timestamp,
       groundingMetadata: meta.groundingMetadata || null,
       modelStatus: meta.modelStatus || null,
-      estimatedCost: computeCost(meta.modelVersion, promptTokens, responseTokens) ?? computeCost(meta.requestedModel, promptTokens, responseTokens)
+      estimatedCost: this._estimatedCost(meta.modelVersion, promptTokens, responseTokens, thoughtsTokens)
     };
+  }
+  /**
+   * Estimated USD cost, preferring the model id the API echoed (`modelVersion`)
+   * and falling back to the requested model when that build isn't priced.
+   * @param {string|null|undefined} modelVersion
+   * @param {number} promptTokens
+   * @param {number} responseTokens
+   * @param {number} [thoughtsTokens=0]
+   * @returns {number|null}
+   * @protected
+   */
+  _estimatedCost(modelVersion, promptTokens, responseTokens, thoughtsTokens = 0) {
+    return computeCost(modelVersion, promptTokens, responseTokens, thoughtsTokens) ?? computeCost(this.modelName, promptTokens, responseTokens, thoughtsTokens);
   }
   /**
    * Builds a usage object directly from a single API response, WITHOUT reading
@@ -769,11 +801,13 @@ ${contextText}
   _usageFromResponse(response, attempts = 1) {
     const promptTokens = response?.usageMetadata?.promptTokenCount || 0;
     const responseTokens = response?.usageMetadata?.candidatesTokenCount || 0;
-    const totalTokens = response?.usageMetadata?.totalTokenCount || 0;
+    const thoughtsTokens = response?.usageMetadata?.thoughtsTokenCount || 0;
+    const totalTokens = response?.usageMetadata?.totalTokenCount || promptTokens + responseTokens + thoughtsTokens;
     const modelVersion = response?.modelVersion || null;
     return {
       promptTokens,
       responseTokens,
+      thoughtsTokens,
       totalTokens,
       attempts,
       modelVersion,
@@ -781,7 +815,7 @@ ${contextText}
       timestamp: Date.now(),
       groundingMetadata: response?.candidates?.[0]?.groundingMetadata || null,
       modelStatus: response?.modelStatus || null,
-      estimatedCost: computeCost(modelVersion, promptTokens, responseTokens) ?? computeCost(this.modelName, promptTokens, responseTokens)
+      estimatedCost: this._estimatedCost(modelVersion, promptTokens, responseTokens, thoughtsTokens)
     };
   }
   // ── Token Estimation ─────────────────────────────────────────────────────
@@ -817,13 +851,13 @@ ${contextText}
    */
   async estimateCost(nextPayload) {
     const tokenInfo = await this.estimate(nextPayload);
-    const pricing = MODEL_PRICING[this.modelName] || { input: 0, output: 0 };
+    const pricing = resolvePricing(this.modelName);
     return {
       inputTokens: tokenInfo.inputTokens,
       model: this.modelName,
       pricing,
-      estimatedInputCost: tokenInfo.inputTokens / 1e6 * pricing.input,
-      note: "Cost is for input tokens only; output cost depends on response length"
+      estimatedInputCost: pricing ? tokenInfo.inputTokens / 1e6 * pricing.input : null,
+      note: pricing ? "Cost is for input tokens only; output cost depends on response length" : `No pricing known for model "${this.modelName}"; estimatedInputCost is null`
     };
   }
   // ── Context Caching ─────────────────────────────────────────────────────
@@ -1464,14 +1498,7 @@ var Message = class extends base_default {
   async init(force = false) {
     if (this._initialized && !force) return;
     logger_default.debug(`Initializing ${this.constructor.name} with model: ${this.modelName}...`);
-    if (this.healthCheck) {
-      try {
-        await this._withRetry(() => this.genAIClient.models.list());
-        logger_default.debug(`${this.constructor.name}: API connection successful.`);
-      } catch (e) {
-        throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
-      }
-    }
+    await this._healthCheckPing();
     this._initialized = true;
     logger_default.debug(`${this.constructor.name}: Initialized (stateless mode).`);
   }
@@ -1502,6 +1529,7 @@ var Message = class extends base_default {
     this._cumulativeUsage = {
       promptTokens: this.lastResponseMetadata.promptTokens,
       responseTokens: this.lastResponseMetadata.responseTokens,
+      thoughtsTokens: this.lastResponseMetadata.thoughtsTokens,
       totalTokens: this.lastResponseMetadata.totalTokens,
       attempts: 1
     };
@@ -3125,14 +3153,7 @@ var Embedding = class extends base_default {
   async init(force = false) {
     if (this._initialized && !force) return;
     logger_default.debug(`Initializing ${this.constructor.name} with model: ${this.modelName}...`);
-    if (this.healthCheck) {
-      try {
-        await this._withRetry(() => this.genAIClient.models.list());
-        logger_default.debug(`${this.constructor.name}: API connection successful.`);
-      } catch (e) {
-        throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
-      }
-    }
+    await this._healthCheckPing();
     this._initialized = true;
     logger_default.debug(`${this.constructor.name}: Initialized (stateless mode).`);
   }
@@ -3264,14 +3285,7 @@ var ImageGenerator = class extends base_default {
   async init(force = false) {
     if (this._initialized && !force) return;
     logger_default.debug(`Initializing ${this.constructor.name} with model: ${this.modelName}...`);
-    if (this.healthCheck) {
-      try {
-        await this._withRetry(() => this.genAIClient.models.list());
-        logger_default.debug(`${this.constructor.name}: API connection successful.`);
-      } catch (e) {
-        throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
-      }
-    }
+    await this._healthCheckPing();
     this._initialized = true;
   }
   /**
@@ -3318,6 +3332,7 @@ var ImageGenerator = class extends base_default {
     this._cumulativeUsage = {
       promptTokens: this.lastResponseMetadata.promptTokens,
       responseTokens: this.lastResponseMetadata.responseTokens,
+      thoughtsTokens: this.lastResponseMetadata.thoughtsTokens,
       totalTokens: this.lastResponseMetadata.totalTokens,
       attempts: 1
     };

--- a/index.cjs
+++ b/index.cjs
@@ -36,15 +36,20 @@ __export(index_exports, {
   HarmBlockThreshold: () => import_genai2.HarmBlockThreshold,
   HarmCategory: () => import_genai2.HarmCategory,
   ImageGenerator: () => ImageGenerator,
+  MODEL_ALIASES: () => MODEL_ALIASES,
+  MODEL_PRICING: () => MODEL_PRICING,
   Message: () => message_default,
   RagAgent: () => rag_agent_default,
   ThinkingLevel: () => import_genai2.ThinkingLevel,
   ToolAgent: () => tool_agent_default,
   Transformer: () => transformer_default,
   attemptJSONRecovery: () => attemptJSONRecovery,
+  computeCost: () => computeCost,
   default: () => index_default,
   extractJSON: () => extractJSON,
-  log: () => logger_default
+  log: () => logger_default,
+  resolvePricing: () => resolvePricing,
+  validateSchema: () => validateSchema
 });
 module.exports = __toCommonJS(index_exports);
 
@@ -255,6 +260,76 @@ function findCompleteJSONStructures(text) {
   }
   return results;
 }
+function validateSchema(data, schema, path2 = "$") {
+  const errors = [];
+  if (!schema || typeof schema !== "object") return errors;
+  if (Array.isArray(schema.enum)) {
+    const ok = schema.enum.some((v) => v === data);
+    if (!ok) errors.push(`${path2}: value ${JSON.stringify(data)} is not one of allowed enum values ${JSON.stringify(schema.enum)}`);
+  }
+  if (schema.type !== void 0) {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    if (!types.some((t) => matchesType(data, t))) {
+      errors.push(`${path2}: expected type ${types.join("|")} but got ${describeType(data)}`);
+      return errors;
+    }
+  }
+  const isObject = data !== null && typeof data === "object" && !Array.isArray(data);
+  if (isObject && (schema.properties || schema.required || schema.additionalProperties === false)) {
+    const props = schema.properties || {};
+    if (Array.isArray(schema.required)) {
+      for (const key of schema.required) {
+        if (!(key in data)) errors.push(`${path2}: missing required property "${key}"`);
+      }
+    }
+    if (schema.additionalProperties === false) {
+      for (const key of Object.keys(data)) {
+        if (!(key in props)) errors.push(`${path2}: unexpected property "${key}" (additionalProperties is false)`);
+      }
+    }
+    for (const [key, subSchema] of Object.entries(props)) {
+      if (key in data) {
+        errors.push(...validateSchema(
+          data[key],
+          /** @type {any} */
+          subSchema,
+          `${path2}.${key}`
+        ));
+      }
+    }
+  }
+  if (Array.isArray(data) && schema.items && typeof schema.items === "object" && !Array.isArray(schema.items)) {
+    data.forEach((item, i) => {
+      errors.push(...validateSchema(item, schema.items, `${path2}[${i}]`));
+    });
+  }
+  return errors;
+}
+function matchesType(value, type) {
+  switch (type) {
+    case "string":
+      return typeof value === "string";
+    case "number":
+      return typeof value === "number" && !Number.isNaN(value);
+    case "integer":
+      return typeof value === "number" && Number.isInteger(value);
+    case "boolean":
+      return typeof value === "boolean";
+    case "object":
+      return value !== null && typeof value === "object" && !Array.isArray(value);
+    case "array":
+      return Array.isArray(value);
+    case "null":
+      return value === null;
+    default:
+      return true;
+  }
+}
+function describeType(value) {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
 function extractJSON(text) {
   if (!text || typeof text !== "string") {
     throw new Error("No text provided for JSON extraction");
@@ -359,6 +434,23 @@ var MODEL_PRICING = {
   // Embeddings
   "gemini-embedding-001": { input: 0.15, output: 0 }
 };
+var MODEL_ALIASES = {
+  "gemini-flash-latest": "gemini-3.5-flash",
+  "gemini-pro-latest": "gemini-3.1-pro-preview",
+  "gemini-flash-lite-latest": "gemini-3.1-flash-lite"
+};
+function resolvePricing(modelId) {
+  if (!modelId) return null;
+  if (MODEL_PRICING[modelId]) return MODEL_PRICING[modelId];
+  const alias = MODEL_ALIASES[modelId];
+  if (alias && MODEL_PRICING[alias]) return MODEL_PRICING[alias];
+  return null;
+}
+function computeCost(modelId, promptTokens, responseTokens) {
+  const pricing = resolvePricing(modelId);
+  if (!pricing) return null;
+  return promptTokens / 1e6 * pricing.input + responseTokens / 1e6 * pricing.output;
+}
 var BaseGemini = class {
   /**
    * @param {BaseGeminiOptions} [options={}]
@@ -634,16 +726,49 @@ ${contextText}
     const meta = this.lastResponseMetadata;
     const cumulative = this._cumulativeUsage || { promptTokens: 0, responseTokens: 0, totalTokens: 0, attempts: 1 };
     const useCumulative = cumulative.attempts > 0;
+    const promptTokens = useCumulative ? cumulative.promptTokens : meta.promptTokens;
+    const responseTokens = useCumulative ? cumulative.responseTokens : meta.responseTokens;
+    const totalTokens = useCumulative ? cumulative.totalTokens : meta.totalTokens;
     return {
-      promptTokens: useCumulative ? cumulative.promptTokens : meta.promptTokens,
-      responseTokens: useCumulative ? cumulative.responseTokens : meta.responseTokens,
-      totalTokens: useCumulative ? cumulative.totalTokens : meta.totalTokens,
+      promptTokens,
+      responseTokens,
+      totalTokens,
       attempts: useCumulative ? cumulative.attempts : 1,
       modelVersion: meta.modelVersion,
       requestedModel: meta.requestedModel,
       timestamp: meta.timestamp,
       groundingMetadata: meta.groundingMetadata || null,
-      modelStatus: meta.modelStatus || null
+      modelStatus: meta.modelStatus || null,
+      estimatedCost: computeCost(meta.modelVersion || meta.requestedModel, promptTokens, responseTokens)
+    };
+  }
+  /**
+   * Builds a usage object directly from a single API response, WITHOUT reading
+   * mutable instance state (`lastResponseMetadata`/`_cumulativeUsage`). Safe to
+   * call under concurrent send() calls on a shared instance — unlike
+   * getLastUsage(), which reflects whichever call most recently mutated the
+   * instance and can cross-talk between concurrent sends.
+   * @param {Object} response - A single generateContent() response
+   * @param {number} [attempts=1] - Attempts this call consumed
+   * @returns {UsageData}
+   * @protected
+   */
+  _usageFromResponse(response, attempts = 1) {
+    const promptTokens = response?.usageMetadata?.promptTokenCount || 0;
+    const responseTokens = response?.usageMetadata?.candidatesTokenCount || 0;
+    const totalTokens = response?.usageMetadata?.totalTokenCount || 0;
+    const modelVersion = response?.modelVersion || null;
+    return {
+      promptTokens,
+      responseTokens,
+      totalTokens,
+      attempts,
+      modelVersion,
+      requestedModel: this.modelName,
+      timestamp: Date.now(),
+      groundingMetadata: response?.candidates?.[0]?.groundingMetadata || null,
+      modelStatus: response?.modelStatus || null,
+      estimatedCost: computeCost(modelVersion || this.modelName, promptTokens, responseTokens)
     };
   }
   // ── Token Estimation ─────────────────────────────────────────────────────
@@ -1310,6 +1435,9 @@ var Message = class extends base_default {
     }
     if (options.responseMimeType) {
       this.chatConfig.responseMimeType = options.responseMimeType;
+    } else if (options.responseSchema) {
+      this.chatConfig.responseMimeType = "application/json";
+      logger_default.debug("responseSchema set without responseMimeType \u2014 defaulting responseMimeType to 'application/json'.");
     }
     this._isStructured = !!(options.responseSchema || options.responseMimeType === "application/json");
     logger_default.debug(`Message created (structured=${this._isStructured})`);
@@ -1323,11 +1451,13 @@ var Message = class extends base_default {
   async init(force = false) {
     if (this._initialized && !force) return;
     logger_default.debug(`Initializing ${this.constructor.name} with model: ${this.modelName}...`);
-    try {
-      await this.genAIClient.models.list();
-      logger_default.debug(`${this.constructor.name}: API connection successful.`);
-    } catch (e) {
-      throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
+    if (this.healthCheck) {
+      try {
+        await this._withRetry(() => this.genAIClient.models.list());
+        logger_default.debug(`${this.constructor.name}: API connection successful.`);
+      } catch (e) {
+        throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
+      }
     }
     this._initialized = true;
     logger_default.debug(`${this.constructor.name}: Initialized (stateless mode).`);
@@ -1354,6 +1484,7 @@ var Message = class extends base_default {
         ...this.vertexai && Object.keys(mergedLabels).length > 0 && { labels: mergedLabels }
       }
     }));
+    const usage = this._usageFromResponse(result);
     this._captureMetadata(result);
     this._cumulativeUsage = {
       promptTokens: this.lastResponseMetadata.promptTokens,
@@ -1367,7 +1498,7 @@ var Message = class extends base_default {
     const text = result.text || "";
     const response = {
       text,
-      usage: this.getLastUsage()
+      usage
     };
     if (this._isStructured) {
       try {
@@ -2981,11 +3112,13 @@ var Embedding = class extends base_default {
   async init(force = false) {
     if (this._initialized && !force) return;
     logger_default.debug(`Initializing ${this.constructor.name} with model: ${this.modelName}...`);
-    try {
-      await this.genAIClient.models.list();
-      logger_default.debug(`${this.constructor.name}: API connection successful.`);
-    } catch (e) {
-      throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
+    if (this.healthCheck) {
+      try {
+        await this._withRetry(() => this.genAIClient.models.list());
+        logger_default.debug(`${this.constructor.name}: API connection successful.`);
+      } catch (e) {
+        throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
+      }
     }
     this._initialized = true;
     logger_default.debug(`${this.constructor.name}: Initialized (stateless mode).`);
@@ -3118,11 +3251,13 @@ var ImageGenerator = class extends base_default {
   async init(force = false) {
     if (this._initialized && !force) return;
     logger_default.debug(`Initializing ${this.constructor.name} with model: ${this.modelName}...`);
-    try {
-      await this.genAIClient.models.list();
-      logger_default.debug(`${this.constructor.name}: API connection successful.`);
-    } catch (e) {
-      throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
+    if (this.healthCheck) {
+      try {
+        await this._withRetry(() => this.genAIClient.models.list());
+        logger_default.debug(`${this.constructor.name}: API connection successful.`);
+      } catch (e) {
+        throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
+      }
     }
     this._initialized = true;
   }
@@ -3165,6 +3300,7 @@ var ImageGenerator = class extends base_default {
       contents: [{ role: "user", parts }],
       config: this._buildConfig(opts)
     }));
+    const usage = this._usageFromResponse(result);
     this._captureMetadata(result);
     this._cumulativeUsage = {
       promptTokens: this.lastResponseMetadata.promptTokens,
@@ -3188,7 +3324,7 @@ var ImageGenerator = class extends base_default {
     if (images.length === 0) {
       logger_default.warn("ImageGenerator: no images returned. Check prompt or safety filters.");
     }
-    return { images, text: text || null, usage: this.getLastUsage() };
+    return { images, text: text || null, usage };
   }
   /**
    * Convenience: write one or all images to disk.
@@ -3248,12 +3384,17 @@ var index_default = { Transformer: transformer_default, Chat: chat_default, Mess
   HarmBlockThreshold,
   HarmCategory,
   ImageGenerator,
+  MODEL_ALIASES,
+  MODEL_PRICING,
   Message,
   RagAgent,
   ThinkingLevel,
   ToolAgent,
   Transformer,
   attemptJSONRecovery,
+  computeCost,
   extractJSON,
-  log
+  log,
+  resolvePricing,
+  validateSchema
 });

--- a/index.js
+++ b/index.js
@@ -29,9 +29,10 @@ export { default as RagAgent } from './rag-agent.js';
 export { default as Embedding } from './embedding.js';
 export { default as ImageGenerator } from './image-generator.js';
 export { default as BaseGemini } from './base.js';
+export { MODEL_PRICING, MODEL_ALIASES, resolvePricing, computeCost } from './base.js';
 export { default as log } from './logger.js';
 export { ThinkingLevel, HarmCategory, HarmBlockThreshold } from '@google/genai';
-export { extractJSON, attemptJSONRecovery } from './json-helpers.js';
+export { extractJSON, attemptJSONRecovery, validateSchema } from './json-helpers.js';
 
 // ── Default Export (namespace object) ──
 

--- a/json-helpers.js
+++ b/json-helpers.js
@@ -282,18 +282,27 @@ function findCompleteJSONStructures(text) {
  * @returns {string[]} Array of human-readable error strings; empty means valid.
  */
 export function validateSchema(data, schema, path = '$') {
+	// NOTE: ak-gemini enforces structured output natively (responseSchema), so this
+	// validator has no runtime call site here — it exists for cross-package API
+	// symmetry with ak-claude (whose Vertex fallback path relies on it). Keep this
+	// implementation byte-identical to ak-claude/json-helpers.js; apply fixes to both.
 	const errors = [];
 	if (!schema || typeof schema !== 'object') return errors;
 
-	// ── enum ──
+	// ── nullable (OpenAPI-style) ── a null value is valid on a nullable node.
+	if (data === null && schema.nullable === true) return errors;
+
+	// ── enum ── strict equality first, then deep-equal for object/array members.
 	if (Array.isArray(schema.enum)) {
-		const ok = schema.enum.some(v => v === data);
+		const target = JSON.stringify(data);
+		const ok = schema.enum.some(v => v === data || JSON.stringify(v) === target);
 		if (!ok) errors.push(`${path}: value ${JSON.stringify(data)} is not one of allowed enum values ${JSON.stringify(schema.enum)}`);
 	}
 
 	// ── type ──
 	if (schema.type !== undefined) {
 		const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+		if (schema.nullable === true) types.push('null');
 		if (!types.some(t => matchesType(data, t))) {
 			errors.push(`${path}: expected type ${types.join('|')} but got ${describeType(data)}`);
 			// If the type is wrong, deeper checks are meaningless — stop here for this node.
@@ -301,25 +310,25 @@ export function validateSchema(data, schema, path = '$') {
 		}
 	}
 
-	// ── object ──
+	// ── object ── (Object.hasOwn avoids prototype-chain keys like 'toString')
 	const isObject = data !== null && typeof data === 'object' && !Array.isArray(data);
 	if (isObject && (schema.properties || schema.required || schema.additionalProperties === false)) {
 		const props = schema.properties || {};
 
 		if (Array.isArray(schema.required)) {
 			for (const key of schema.required) {
-				if (!(key in data)) errors.push(`${path}: missing required property "${key}"`);
+				if (!Object.hasOwn(data, key)) errors.push(`${path}: missing required property "${key}"`);
 			}
 		}
 
 		if (schema.additionalProperties === false) {
 			for (const key of Object.keys(data)) {
-				if (!(key in props)) errors.push(`${path}: unexpected property "${key}" (additionalProperties is false)`);
+				if (!Object.hasOwn(props, key)) errors.push(`${path}: unexpected property "${key}" (additionalProperties is false)`);
 			}
 		}
 
 		for (const [key, subSchema] of Object.entries(props)) {
-			if (key in data) {
+			if (Object.hasOwn(data, key)) {
 				errors.push(...validateSchema(data[key], /** @type {any} */ (subSchema), `${path}.${key}`));
 			}
 		}

--- a/json-helpers.js
+++ b/json-helpers.js
@@ -268,6 +268,102 @@ function findCompleteJSONStructures(text) {
 }
 
 /**
+ * Validates a parsed value against a (subset of) JSON Schema. Dependency-light —
+ * intended to guard fallback structured-output paths where the model isn't forced
+ * to emit schema-valid JSON.
+ *
+ * Supported keywords: `type` (string or array of strings; 'integer' checks for
+ * whole numbers), `required`, `properties`, `additionalProperties: false`,
+ * `items` (single schema), `enum`. Unknown keywords are ignored (lenient).
+ *
+ * @param {*} data - The parsed value to validate
+ * @param {Object} schema - JSON Schema object
+ * @param {string} [path='$'] - Internal: JSON path prefix for error messages
+ * @returns {string[]} Array of human-readable error strings; empty means valid.
+ */
+export function validateSchema(data, schema, path = '$') {
+	const errors = [];
+	if (!schema || typeof schema !== 'object') return errors;
+
+	// ── enum ──
+	if (Array.isArray(schema.enum)) {
+		const ok = schema.enum.some(v => v === data);
+		if (!ok) errors.push(`${path}: value ${JSON.stringify(data)} is not one of allowed enum values ${JSON.stringify(schema.enum)}`);
+	}
+
+	// ── type ──
+	if (schema.type !== undefined) {
+		const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+		if (!types.some(t => matchesType(data, t))) {
+			errors.push(`${path}: expected type ${types.join('|')} but got ${describeType(data)}`);
+			// If the type is wrong, deeper checks are meaningless — stop here for this node.
+			return errors;
+		}
+	}
+
+	// ── object ──
+	const isObject = data !== null && typeof data === 'object' && !Array.isArray(data);
+	if (isObject && (schema.properties || schema.required || schema.additionalProperties === false)) {
+		const props = schema.properties || {};
+
+		if (Array.isArray(schema.required)) {
+			for (const key of schema.required) {
+				if (!(key in data)) errors.push(`${path}: missing required property "${key}"`);
+			}
+		}
+
+		if (schema.additionalProperties === false) {
+			for (const key of Object.keys(data)) {
+				if (!(key in props)) errors.push(`${path}: unexpected property "${key}" (additionalProperties is false)`);
+			}
+		}
+
+		for (const [key, subSchema] of Object.entries(props)) {
+			if (key in data) {
+				errors.push(...validateSchema(data[key], /** @type {any} */ (subSchema), `${path}.${key}`));
+			}
+		}
+	}
+
+	// ── array ──
+	if (Array.isArray(data) && schema.items && typeof schema.items === 'object' && !Array.isArray(schema.items)) {
+		data.forEach((item, i) => {
+			errors.push(...validateSchema(item, schema.items, `${path}[${i}]`));
+		});
+	}
+
+	return errors;
+}
+
+/**
+ * @param {*} value
+ * @param {string} type - JSON Schema type name
+ * @returns {boolean}
+ */
+function matchesType(value, type) {
+	switch (type) {
+		case 'string': return typeof value === 'string';
+		case 'number': return typeof value === 'number' && !Number.isNaN(value);
+		case 'integer': return typeof value === 'number' && Number.isInteger(value);
+		case 'boolean': return typeof value === 'boolean';
+		case 'object': return value !== null && typeof value === 'object' && !Array.isArray(value);
+		case 'array': return Array.isArray(value);
+		case 'null': return value === null;
+		default: return true; // unknown type keyword — be lenient
+	}
+}
+
+/**
+ * @param {*} value
+ * @returns {string}
+ */
+function describeType(value) {
+	if (value === null) return 'null';
+	if (Array.isArray(value)) return 'array';
+	return typeof value;
+}
+
+/**
  * Extracts valid JSON from model response text using multiple strategies.
  * @param {string} text - The model response text
  * @returns {Object} - Parsed JSON object

--- a/message.js
+++ b/message.js
@@ -53,6 +53,13 @@ class Message extends BaseGemini {
 		}
 		if (options.responseMimeType) {
 			this.chatConfig.responseMimeType = options.responseMimeType;
+		} else if (options.responseSchema) {
+			// Google's @google/genai requires response_mime_type: 'application/json'
+			// whenever a responseSchema is set — it does NOT add it automatically.
+			// Passing a schema without the mime type yields a 400 INVALID_ARGUMENT
+			// (Vertex) or prose output that fails JSON extraction. Auto-pair them.
+			this.chatConfig.responseMimeType = 'application/json';
+			log.debug("responseSchema set without responseMimeType — defaulting responseMimeType to 'application/json'.");
 		}
 
 		this._isStructured = !!(options.responseSchema || options.responseMimeType === 'application/json');
@@ -71,11 +78,17 @@ class Message extends BaseGemini {
 
 		log.debug(`Initializing ${this.constructor.name} with model: ${this.modelName}...`);
 
-		try {
-			await this.genAIClient.models.list();
-			log.debug(`${this.constructor.name}: API connection successful.`);
-		} catch (e) {
-			throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
+		// Connectivity check is opt-in (healthCheck: true). models.list() is a
+		// different IAM surface than generateContent — a service account allowed to
+		// generate but not list publisher models would fail here misleadingly — and
+		// it adds a round-trip per instance. The first send() is a fine error signal.
+		if (this.healthCheck) {
+			try {
+				await this._withRetry(() => this.genAIClient.models.list());
+				log.debug(`${this.constructor.name}: API connection successful.`);
+			} catch (e) {
+				throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
+			}
 		}
 
 		this._initialized = true;
@@ -111,6 +124,11 @@ class Message extends BaseGemini {
 			}
 		}));
 
+		// Compute per-call usage synchronously from THIS response before any other
+		// concurrent send() can mutate instance state. result.usage is safe under
+		// concurrency; getLastUsage() (instance state, updated below) is not.
+		const usage = this._usageFromResponse(result);
+
 		this._captureMetadata(result);
 
 		this._cumulativeUsage = {
@@ -127,7 +145,7 @@ class Message extends BaseGemini {
 		const text = result.text || '';
 		const response = {
 			text,
-			usage: this.getLastUsage()
+			usage
 		};
 
 		// Parse structured data if configured

--- a/message.js
+++ b/message.js
@@ -82,14 +82,7 @@ class Message extends BaseGemini {
 		// different IAM surface than generateContent — a service account allowed to
 		// generate but not list publisher models would fail here misleadingly — and
 		// it adds a round-trip per instance. The first send() is a fine error signal.
-		if (this.healthCheck) {
-			try {
-				await this._withRetry(() => this.genAIClient.models.list());
-				log.debug(`${this.constructor.name}: API connection successful.`);
-			} catch (e) {
-				throw new Error(`${this.constructor.name} initialization failed: ${e.message}`);
-			}
-		}
+		await this._healthCheckPing();
 
 		this._initialized = true;
 		log.debug(`${this.constructor.name}: Initialized (stateless mode).`);
@@ -134,6 +127,7 @@ class Message extends BaseGemini {
 		this._cumulativeUsage = {
 			promptTokens: this.lastResponseMetadata.promptTokens,
 			responseTokens: this.lastResponseMetadata.responseTokens,
+			thoughtsTokens: this.lastResponseMetadata.thoughtsTokens,
 			totalTokens: this.lastResponseMetadata.totalTokens,
 			attempts: 1
 		};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ak-gemini",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ak-gemini",
-			"version": "2.4.0",
+			"version": "2.4.1",
 			"license": "ISC",
 			"dependencies": {
 				"@google/genai": "^2.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "ak-gemini",
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ak-gemini",
-			"version": "2.4.1",
+			"version": "2.4.2",
 			"license": "ISC",
 			"dependencies": {
-				"@google/genai": "^2.10.0",
+				"@google/genai": "^2.12.0",
 				"dotenv": "^17.3.1",
 				"pino": "^10.3.1",
 				"pino-pretty": "^13.1.3"
@@ -1016,9 +1016,9 @@
 			}
 		},
 		"node_modules/@google/genai": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.10.0.tgz",
-			"integrity": "sha512-e4cFxj3tiuMtsgOT4G9c1hXyGJhg7/Buj7VVeBacRY3fRtkRZZ59Q3nuVp2xbq8BGQXLXCDB253qMhklMOeUDg==",
+			"version": "2.12.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.12.0.tgz",
+			"integrity": "sha512-LUr972DZosqPUhf9Mb3CIVu/B99woD3QW6ZJV1T9aNgxaoimAZARmo+IyyDsxIL+zouFiYSdA4hzfEWXc9oNIQ==",
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "ak-gemini",
 	"author": "ak@mixpanel.com",
 	"description": "AK's Generative AI Helper for doing... everything",
-	"version": "2.4.2",
+	"version": "2.5.0",
 	"main": "index.js",
 	"files": [
 		"index.js",
@@ -19,7 +19,8 @@
 		"json-helpers.js",
 		"types.d.ts",
 		"logger.js",
-		"GUIDE.md"
+		"GUIDE.md",
+		"CHANGELOG.md"
 	],
 	"types": "types.d.ts",
 	"exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "ak-gemini",
 	"author": "ak@mixpanel.com",
 	"description": "AK's Generative AI Helper for doing... everything",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"main": "index.js",
 	"files": [
 		"index.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "ak-gemini",
 	"author": "ak@mixpanel.com",
 	"description": "AK's Generative AI Helper for doing... everything",
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"main": "index.js",
 	"files": [
 		"index.js",
@@ -65,7 +65,7 @@
 	],
 	"license": "ISC",
 	"dependencies": {
-		"@google/genai": "^2.10.0",
+		"@google/genai": "^2.12.0",
 		"dotenv": "^17.3.1",
 		"pino": "^10.3.1",
 		"pino-pretty": "^13.1.3"

--- a/tests/consumer-fixes.test.js
+++ b/tests/consumer-fixes.test.js
@@ -1,0 +1,172 @@
+/**
+ * @fileoverview Offline (mocked) unit tests for the 2026-07 consumer-review fixes.
+ * These do NOT hit the real API — the genAIClient is stubbed on the instance.
+ * Covers: responseMimeType auto-pairing (#1), init() healthCheck gating (#3),
+ * concurrency-safe per-call usage (#4), estimatedCost + alias pricing (#5).
+ */
+
+import { jest } from '@jest/globals';
+import { Message } from '../index.js';
+import { validateSchema, resolvePricing, computeCost } from '../index.js';
+
+const KEY = { apiKey: 'test-key', logLevel: 'silent' };
+
+/** Replace the SDK client with a stub so nothing hits the network. */
+function stubGen(msg, generateContent, list) {
+	msg.genAIClient = {
+		models: {
+			generateContent: generateContent || jest.fn(),
+			list: list || jest.fn(async () => [])
+		}
+	};
+}
+
+function fakeResponse(text, prompt, candidates, modelVersion = 'gemini-2.5-flash') {
+	return {
+		text,
+		modelVersion,
+		usageMetadata: {
+			promptTokenCount: prompt,
+			candidatesTokenCount: candidates,
+			totalTokenCount: prompt + candidates
+		}
+	};
+}
+
+describe('consumer-fixes (ak-gemini)', () => {
+
+	// ── #1 responseMimeType auto-pairing ──
+	describe('#1 responseSchema auto-pairs responseMimeType', () => {
+		const schema = { type: 'object', properties: { a: { type: 'string' } } };
+
+		it('defaults responseMimeType to application/json when only responseSchema given', () => {
+			const msg = new Message({ ...KEY, responseSchema: schema });
+			expect(msg.chatConfig.responseMimeType).toBe('application/json');
+			expect(msg.chatConfig.responseSchema).toBe(schema);
+		});
+
+		it('respects an explicit responseMimeType', () => {
+			const msg = new Message({ ...KEY, responseSchema: schema, responseMimeType: 'text/x.enum' });
+			expect(msg.chatConfig.responseMimeType).toBe('text/x.enum');
+		});
+
+		it('does not set responseMimeType when no schema and no mime type', () => {
+			const msg = new Message({ ...KEY });
+			expect(msg.chatConfig.responseMimeType).toBeUndefined();
+		});
+	});
+
+	// ── #3 init() healthCheck gating ──
+	describe('#3 init() does not call models.list() unless healthCheck', () => {
+		it('performs no network call on init by default', async () => {
+			const msg = new Message({ ...KEY });
+			const list = jest.fn(async () => []);
+			stubGen(msg, jest.fn(), list);
+			await msg.init();
+			expect(list).not.toHaveBeenCalled();
+		});
+
+		it('calls models.list() when healthCheck: true', async () => {
+			const msg = new Message({ ...KEY, healthCheck: true });
+			const list = jest.fn(async () => []);
+			stubGen(msg, jest.fn(), list);
+			await msg.init();
+			expect(list).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	// ── #4 concurrency-safe per-call usage ──
+	describe('#4 concurrent send() results carry their own usage', () => {
+		it('does not cross-talk usage between concurrent sends', async () => {
+			const msg = new Message({ ...KEY });
+			// token count keyed by payload; delays interleave completion order
+			const N = { A: 10, B: 20, C: 30 };
+			const D = { A: 30, B: 10, C: 20 };
+			const generateContent = jest.fn(async ({ contents }) => {
+				const txt = contents[0].parts[0].text;
+				await new Promise(r => setTimeout(r, D[txt]));
+				return fakeResponse(`resp-${txt}`, N[txt], N[txt] * 2);
+			});
+			stubGen(msg, generateContent);
+
+			const [ra, rb, rc] = await Promise.all([msg.send('A'), msg.send('B'), msg.send('C')]);
+			expect(ra.usage.promptTokens).toBe(10);
+			expect(ra.usage.responseTokens).toBe(20);
+			expect(ra.usage.totalTokens).toBe(30);
+			expect(rb.usage.totalTokens).toBe(60);
+			expect(rc.usage.totalTokens).toBe(90);
+		});
+	});
+
+	// ── #5 estimatedCost + alias pricing ──
+	describe('#5 estimatedCost in usage', () => {
+		it('computes non-null estimatedCost for a priced model', async () => {
+			const msg = new Message({ ...KEY });
+			stubGen(msg, jest.fn(async () => fakeResponse('r', 1_000_000, 1_000_000, 'gemini-2.5-flash')));
+			const r = await msg.send('hi');
+			// gemini-2.5-flash: input 0.30, output 2.50 per M
+			expect(r.usage.estimatedCost).toBeCloseTo(0.30 + 2.50, 5);
+		});
+
+		it('returns null estimatedCost for an unknown model', async () => {
+			const msg = new Message({ ...KEY });
+			stubGen(msg, jest.fn(async () => fakeResponse('r', 100, 100, 'some-unknown-model')));
+			const r = await msg.send('hi');
+			expect(r.usage.estimatedCost).toBeNull();
+		});
+
+		it('resolves -latest aliases for pricing', () => {
+			expect(resolvePricing('gemini-flash-latest')).toEqual(resolvePricing('gemini-3.5-flash'));
+			expect(resolvePricing('gemini-pro-latest')).toEqual(resolvePricing('gemini-3.1-pro-preview'));
+			expect(resolvePricing('totally-made-up')).toBeNull();
+		});
+
+		it('computeCost returns null for unknown model', () => {
+			expect(computeCost('nope', 100, 100)).toBeNull();
+			expect(computeCost('gemini-2.5-flash', 1_000_000, 0)).toBeCloseTo(0.30, 5);
+		});
+	});
+
+	// ── validateSchema (shared helper) ──
+	describe('validateSchema()', () => {
+		const schema = {
+			type: 'object',
+			required: ['source', 'count'],
+			additionalProperties: false,
+			properties: {
+				source: { type: 'string', enum: ['web', 'db'] },
+				count: { type: 'integer' },
+				tags: { type: 'array', items: { type: 'string' } }
+			}
+		};
+
+		it('passes a valid object', () => {
+			expect(validateSchema({ source: 'web', count: 3, tags: ['a'] }, schema)).toEqual([]);
+		});
+
+		it('flags a bad enum value', () => {
+			const errs = validateSchema({ source: 'ftp', count: 1 }, schema);
+			expect(errs.some(e => e.includes('enum'))).toBe(true);
+		});
+
+		it('flags a missing required key', () => {
+			const errs = validateSchema({ source: 'web' }, schema);
+			expect(errs.some(e => e.includes('count'))).toBe(true);
+		});
+
+		it('flags an unexpected property', () => {
+			const errs = validateSchema({ source: 'web', count: 1, extra: true }, schema);
+			expect(errs.some(e => e.includes('extra'))).toBe(true);
+		});
+
+		it('flags a wrong type', () => {
+			const errs = validateSchema({ source: 'web', count: 'x' }, schema);
+			expect(errs.some(e => e.includes('count') && e.includes('integer'))).toBe(true);
+		});
+
+		it('flags a bad array item type', () => {
+			const errs = validateSchema({ source: 'web', count: 1, tags: ['a', 5] }, schema);
+			expect(errs.some(e => e.includes('tags[1]'))).toBe(true);
+		});
+	});
+});

--- a/tests/consumer-fixes.test.js
+++ b/tests/consumer-fixes.test.js
@@ -108,17 +108,37 @@ describe('consumer-fixes (ak-gemini)', () => {
 			expect(r.usage.estimatedCost).toBeCloseTo(0.30 + 2.50, 5);
 		});
 
-		it('returns null estimatedCost for an unknown model', async () => {
-			const msg = new Message({ ...KEY });
+		it('returns null estimatedCost when neither modelVersion nor requestedModel is priced', async () => {
+			const msg = new Message({ ...KEY, modelName: 'some-unknown-model' });
 			stubGen(msg, jest.fn(async () => fakeResponse('r', 100, 100, 'some-unknown-model')));
 			const r = await msg.send('hi');
 			expect(r.usage.estimatedCost).toBeNull();
+		});
+
+		it('falls back to requestedModel pricing when modelVersion is unknown', async () => {
+			const msg = new Message({ ...KEY, modelName: 'gemini-2.5-flash' });
+			stubGen(msg, jest.fn(async () => fakeResponse('r', 1_000_000, 0, 'some-weird-unpriced-build')));
+			const r = await msg.send('hi');
+			expect(r.usage.estimatedCost).toBeCloseTo(0.30, 5);
 		});
 
 		it('resolves -latest aliases for pricing', () => {
 			expect(resolvePricing('gemini-flash-latest')).toEqual(resolvePricing('gemini-3.5-flash'));
 			expect(resolvePricing('gemini-pro-latest')).toEqual(resolvePricing('gemini-3.1-pro-preview'));
 			expect(resolvePricing('totally-made-up')).toBeNull();
+		});
+
+		it('resolves version-suffixed builds the API echoes in modelVersion', () => {
+			// API returns a pinned build (e.g. -001) even when you request the bare id
+			expect(resolvePricing('gemini-2.5-flash-001')).toEqual(resolvePricing('gemini-2.5-flash'));
+			expect(resolvePricing('gemini-3-flash-preview-09-2025')).toEqual(resolvePricing('gemini-3-flash-preview'));
+		});
+
+		it('estimatedCost is non-null when modelVersion carries a build suffix', async () => {
+			const msg = new Message({ ...KEY });
+			stubGen(msg, jest.fn(async () => fakeResponse('r', 1_000_000, 0, 'gemini-2.5-flash-001')));
+			const r = await msg.send('hi');
+			expect(r.usage.estimatedCost).toBeCloseTo(0.30, 5);
 		});
 
 		it('computeCost returns null for unknown model', () => {

--- a/tests/consumer-fixes.test.js
+++ b/tests/consumer-fixes.test.js
@@ -6,7 +6,7 @@
  */
 
 import { jest } from '@jest/globals';
-import { Message } from '../index.js';
+import { Message, Chat } from '../index.js';
 import { validateSchema, resolvePricing, computeCost } from '../index.js';
 
 const KEY = { apiKey: 'test-key', logLevel: 'silent' };
@@ -187,6 +187,72 @@ describe('consumer-fixes (ak-gemini)', () => {
 		it('flags a bad array item type', () => {
 			const errs = validateSchema({ source: 'web', count: 1, tags: ['a', 5] }, schema);
 			expect(errs.some(e => e.includes('tags[1]'))).toBe(true);
+		});
+
+		// S1: nullable, deep-equal enum, prototype-chain keys
+		it('allows null on a nullable field', () => {
+			const s = { type: 'object', properties: { note: { type: 'string', nullable: true } } };
+			expect(validateSchema({ note: null }, s)).toEqual([]);
+			expect(validateSchema({ note: 'hi' }, s)).toEqual([]);
+		});
+
+		it('deep-equals object/array enum members', () => {
+			const s = { enum: [{ a: 1 }, [1, 2]] };
+			expect(validateSchema({ a: 1 }, s)).toEqual([]);
+			expect(validateSchema([1, 2], s)).toEqual([]);
+			expect(validateSchema({ a: 2 }, s).length).toBeGreaterThan(0);
+		});
+
+		it('does not treat prototype keys as present (Object.hasOwn)', () => {
+			const s = { type: 'object', additionalProperties: false, properties: { x: { type: 'number' } } };
+			// 'toString' is on the prototype but NOT an own key — must be allowed absent
+			expect(validateSchema({ x: 1 }, s)).toEqual([]);
+			// required 'toString' must report missing even though 'toString' in {} is true
+			const s2 = { type: 'object', required: ['toString'] };
+			expect(validateSchema({}, s2).some(e => e.includes('toString'))).toBe(true);
+		});
+	});
+
+	// ── #3 thinking tokens in usage + cost ──
+	describe('#3 thoughtsTokens billed at output rate', () => {
+		it('includes thoughts in totalTokens and estimatedCost', async () => {
+			const msg = new Message({ ...KEY, modelName: 'gemini-2.5-flash' });
+			msg.genAIClient = {
+				models: {
+					generateContent: jest.fn(async () => ({
+						text: 'r',
+						modelVersion: 'gemini-2.5-flash',
+						usageMetadata: { promptTokenCount: 1_000_000, candidatesTokenCount: 1_000_000, thoughtsTokenCount: 1_000_000, totalTokenCount: 3_000_000 }
+					})),
+					list: jest.fn()
+				}
+			};
+			const r = await msg.send('hi');
+			expect(r.usage.thoughtsTokens).toBe(1_000_000);
+			expect(r.usage.totalTokens).toBe(3_000_000);
+			// input 0.30 + (candidates 1M + thoughts 1M) * output 2.50 = 0.30 + 5.00
+			expect(r.usage.estimatedCost).toBeCloseTo(0.30 + 5.00, 5);
+		});
+	});
+
+	// ── #1 estimateCost() uses resolvePricing (via Chat — Message.estimate is a no-op) ──
+	describe('#1 estimateCost resolves aliases and nulls unknown', () => {
+		function stubCount(inst, tokens) {
+			inst.genAIClient = { models: { countTokens: jest.fn(async () => ({ totalTokens: tokens })), list: jest.fn() } };
+		}
+		it('resolves a -latest alias (non-null cost)', async () => {
+			const chat = new Chat({ ...KEY, modelName: 'gemini-flash-latest' });
+			stubCount(chat, 1_000_000);
+			const c = await chat.estimateCost('hi');
+			expect(c.estimatedInputCost).not.toBeNull();
+			expect(c.pricing).not.toBeNull();
+		});
+		it('returns null for an unknown model', async () => {
+			const chat = new Chat({ ...KEY, modelName: 'totally-made-up' });
+			stubCount(chat, 1000);
+			const c = await chat.estimateCost('hi');
+			expect(c.estimatedInputCost).toBeNull();
+			expect(c.pricing).toBeNull();
 		});
 	});
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -76,6 +76,8 @@ export interface UsageData {
   groundingMetadata?: GroundingMetadata | null;
   /** Model lifecycle status from Google (e.g., 'DEPRECATED'). Surfaced from @google/genai 1.47+. */
   modelStatus?: string | null;
+  /** Estimated USD cost from MODEL_PRICING (input+output). null when the model's pricing is unknown. */
+  estimatedCost?: number | null;
 }
 
 export interface TransformationExample {
@@ -757,6 +759,17 @@ export declare class ImageGenerator extends BaseGemini {
 
 export declare function extractJSON(text: string): any;
 export declare function attemptJSONRecovery(text: string, maxAttempts?: number): any | null;
+/** Validates a parsed value against a subset of JSON Schema. Returns error strings ([] means valid). */
+export declare function validateSchema(data: any, schema: Record<string, any>, path?: string): string[];
+
+/** Per-million-token pricing keyed by model id. */
+export declare const MODEL_PRICING: Record<string, { input: number; output: number }>;
+/** Floating `-latest` alias → canonical model id, for pricing resolution. */
+export declare const MODEL_ALIASES: Record<string, string>;
+/** Resolves pricing for a model id (follows -latest aliases). null when unknown. */
+export declare function resolvePricing(modelId: string | null | undefined): { input: number; output: number } | null;
+/** Estimated USD cost from token counts. null when the model's pricing is unknown. */
+export declare function computeCost(modelId: string | null | undefined, promptTokens: number, responseTokens: number): number | null;
 
 declare const _default: {
   Transformer: typeof Transformer;

--- a/types.d.ts
+++ b/types.d.ts
@@ -64,7 +64,9 @@ export interface UsageData {
   promptTokens: number;
   /** CUMULATIVE output tokens across all retry attempts */
   responseTokens: number;
-  /** CUMULATIVE total tokens across all retry attempts */
+  /** CUMULATIVE thinking ("thoughts") tokens; billed at the output rate. Included in totalTokens and estimatedCost. */
+  thoughtsTokens?: number;
+  /** CUMULATIVE total tokens across all retry attempts (includes thoughtsTokens) */
   totalTokens: number;
   /** Number of attempts (1 = first try success, 2+ = retries needed) */
   attempts: number;
@@ -604,8 +606,8 @@ export declare class BaseGemini {
   estimateCost(nextPayload: Record<string, unknown> | string): Promise<{
     inputTokens: number;
     model: string;
-    pricing: { input: number; output: number };
-    estimatedInputCost: number;
+    pricing: { input: number; output: number } | null;
+    estimatedInputCost: number | null;
     note: string;
   }>;
 


### PR DESCRIPTION
Fixes surfaced by a downstream consumer's review (Cerebros Pulse) plus two adversarial review passes. See CHANGELOG.md for the full list.

## Highlights
- Auto-pair `responseMimeType: 'application/json'` when `responseSchema` is set (#1).
- `init()` connectivity check is now opt-in via `healthCheck` on Message/Embedding/ImageGenerator (#3).
- Concurrency-safe per-call `result.usage` on the stateless classes; `getLastUsage()` documented as instance-scoped (#4).
- `usage.estimatedCost` from `MODEL_PRICING` (null when unpriced); thinking tokens (`thoughtsTokens`) billed at output rate; `-latest` alias + version-suffix resolution (#5).
- `estimateCost()` uses `resolvePricing()` and returns null (not 0) for unknown models.
- `validateSchema()` exported (nullable, deep-equal enum, Object.hasOwn).

## Deps
- `@google/genai` ^2.10 → ^2.12 (no breaking changes to used surface).

## Verification
- typecheck + build clean; offline `tests/consumer-fixes.test.js` 25/25.
- Live suites not run in CI — run `npm run test:gemini` before publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)